### PR TITLE
Feature/drm rotation

### DIFF
--- a/DRMPlayerItemLoader/Sources/ContentKeyDelegate.swift
+++ b/DRMPlayerItemLoader/Sources/ContentKeyDelegate.swift
@@ -14,13 +14,15 @@ import AVFoundation
     weak var licenseProvider: FairPlayLicenseProvider?
     weak var contentKeySession: AVContentKeySession?
     // MARK: Types
-    var previousRequest: AVContentKeyRequest?
     enum ProgramError: Error {
         case missingApplicationCertificate
         case noCKCReturnedByKSM
     }
     
     // MARK: Properties
+    
+    /// `previousRequest` is the previous license request, and stored it in order to renew next license.
+    private var previousRequest: AVContentKeyRequest?
     
     /// The directory that is used to save persistable content keys.
     lazy var contentKeyDirectory: URL = {

--- a/DRMPlayerItemLoader/Sources/PlayerItemLoader.swift
+++ b/DRMPlayerItemLoader/Sources/PlayerItemLoader.swift
@@ -56,7 +56,7 @@ import AVFoundation
         self.contentKey = contentKey
 
         super.init()
-        setupRenewTimer(interval: 15)
+        setupRenewTimer(interval: renewInterval)
     }
     
     deinit {
@@ -135,7 +135,7 @@ import AVFoundation
     @objc func renewTimerFired(timer: Timer) {
         guard let item = playerItem else { return }
         delegate?.playerItemWillRenewLicense?(item)
-        //TODO: renew drm Licence
+        contentKeyManager?.contentKeyDelegate.renewLicense()
     }
 
     @objc func onErrorLogEntryNotification(notification: Notification) {


### PR DESCRIPTION
### What
Backend的drm License是有10 minutes的期限，必須到期時更新。

### How
在PlayerItemLoader直接處理renew License的，外界只需要處理 error的handle即可。

- 建立Timer去定時更新  DRM License。目前是先抓9分鐘(540秒)，提前一分鐘更新。
   - backend 目前是 10分鐘的期限。
- 在PlayerItemLoader 的initiailizer多開一個參數可以從外部設置時間給 Timer的interval。